### PR TITLE
Unit descriptor overhaul (close #2)

### DIFF
--- a/SharpInit.Ipc/IBaseIpcContext.cs
+++ b/SharpInit.Ipc/IBaseIpcContext.cs
@@ -32,6 +32,9 @@ namespace SharpInit.Ipc
         [IpcFunction("list-units")]
         List<string> ListUnits();
 
+        [IpcFunction("list-unit-files")]
+        List<string> ListUnitFiles();
+
         [IpcFunction("get-unit-info")]
         UnitInfo GetUnitInfo(string unit);
 

--- a/SharpInit.Ipc/SharpInit.Ipc.csproj
+++ b/SharpInit.Ipc/SharpInit.Ipc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SharpInit.Tests/SharpInit.Tests.csproj
+++ b/SharpInit.Tests/SharpInit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SharpInit.Tests/UnitRegistryTests.cs
+++ b/SharpInit.Tests/UnitRegistryTests.cs
@@ -43,6 +43,7 @@ namespace SharpInit.Tests
         public void TestCleanup()
         {
             UnitRegistry.Units.Clear();
+            UnitRegistry.UnitFiles.Clear();
         }
 
         [ClassCleanup]
@@ -52,72 +53,33 @@ namespace SharpInit.Tests
             Directory.Delete(DirectoryName, true);
             Environment.SetEnvironmentVariable("SHARPINIT_UNIT_PATH", null);
         }
-
-        [TestMethod]
-        public void AddUnit_UnitIsAdded_True()
-        {
-            // Arrange
-            ServiceUnitDescriptor descriptor = UnitParser.FromFiles<ServiceUnitDescriptor>(UnitParser.ParseFile(TestUnitPath));
-            Unit unit = new ServiceUnit(descriptor);
-
-            // Act
-            UnitRegistry.AddUnit(unit);
-
-            // Assert
-            Assert.IsTrue(UnitRegistry.Units.Count == 1);
-        }
-
-        [TestMethod]
-        public void AddUnit_UnitIsNull_True()
-        {
-            // Arrange
-            Unit unit = null;
-
-            // Act
-            UnitRegistry.AddUnit(unit);
-
-            // Assert
-            Assert.IsTrue(UnitRegistry.Units.Count == 0);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void AddUnit_UnitHasAlreadyBeenAdded_ThrowsException()
-        {
-            // Arrange
-            ServiceUnitDescriptor descriptor = UnitParser.FromFiles<ServiceUnitDescriptor>(UnitParser.ParseFile(TestUnitPath));
-            Unit unit = new ServiceUnit(descriptor);
-
-            // Act
-            UnitRegistry.AddUnit(unit);
-            UnitRegistry.AddUnit(unit);
-
-            // Assert
-            // Exception Thrown
-        }
         
         [TestMethod]
         public void AddUnitByPath_UnitFound_True()
         {
             // Arrange
+            UnitRegistry.UnitFiles.Clear();
+            UnitRegistry.Units.Clear();
 
             // Act
-            UnitRegistry.AddUnitByPath(TestUnitPath);
+            UnitRegistry.IndexUnitFile(TestUnitPath);
 
             // Assert
-            Assert.IsTrue(UnitRegistry.Units.Count == 1);
+            Assert.IsNotNull(UnitRegistry.GetUnit(TestUnitFilename));
         }
 
         [TestMethod]
         public void AddUnitByPath_UnitNotFound_True()
         {
             // Arrange
+            UnitRegistry.UnitFiles.Clear();
+            UnitRegistry.Units.Clear();
 
             // Act
-            UnitRegistry.AddUnitByPath($"{DirectoryName}/nonexistent-unit.service");
+            UnitRegistry.IndexUnitFile($"{DirectoryName}/nonexistent-unit.service");
 
             // Assert
-            Assert.IsTrue(UnitRegistry.Units.Count == 0);
+            Assert.IsNull(UnitRegistry.GetUnit(TestUnitFilename));
         }
 
         [TestMethod]
@@ -131,7 +93,7 @@ namespace SharpInit.Tests
             var result = UnitRegistry.ScanDefaultDirectories();
 
             // Assert
-            Assert.IsTrue(UnitRegistry.Units.Count > 0);
+            Assert.IsTrue(UnitRegistry.UnitFiles.ContainsKey(TestUnitFilename));
         }
 
         [TestMethod]

--- a/SharpInit.Tests/UnitRegistryTests.cs
+++ b/SharpInit.Tests/UnitRegistryTests.cs
@@ -62,7 +62,7 @@ namespace SharpInit.Tests
             UnitRegistry.Units.Clear();
 
             // Act
-            UnitRegistry.IndexUnitFile(TestUnitPath);
+            UnitRegistry.IndexUnitByPath(TestUnitPath);
 
             // Assert
             Assert.IsNotNull(UnitRegistry.GetUnit(TestUnitFilename));
@@ -76,7 +76,7 @@ namespace SharpInit.Tests
             UnitRegistry.Units.Clear();
 
             // Act
-            UnitRegistry.IndexUnitFile($"{DirectoryName}/nonexistent-unit.service");
+            UnitRegistry.IndexUnitByPath($"{DirectoryName}/nonexistent-unit.service");
 
             // Assert
             Assert.IsNull(UnitRegistry.GetUnit(TestUnitFilename));

--- a/SharpInit.Tests/UnitRegistryTests.cs
+++ b/SharpInit.Tests/UnitRegistryTests.cs
@@ -56,7 +56,8 @@ namespace SharpInit.Tests
         public void AddUnit_UnitIsAdded_True()
         {
             // Arrange
-            Unit unit = new ServiceUnit(TestUnitPath);
+            ServiceUnitDescriptor descriptor = UnitParser.FromFiles<ServiceUnitDescriptor>(UnitParser.ParseFile(TestUnitPath));
+            Unit unit = new ServiceUnit(descriptor);
 
             // Act
             UnitRegistry.AddUnit(unit);
@@ -83,7 +84,8 @@ namespace SharpInit.Tests
         public void AddUnit_UnitHasAlreadyBeenAdded_ThrowsException()
         {
             // Arrange
-            Unit unit = new ServiceUnit(TestUnitPath);
+            ServiceUnitDescriptor descriptor = UnitParser.FromFiles<ServiceUnitDescriptor>(UnitParser.ParseFile(TestUnitPath));
+            Unit unit = new ServiceUnit(descriptor);
 
             // Act
             UnitRegistry.AddUnit(unit);

--- a/SharpInit.Tests/UnitRegistryTests.cs
+++ b/SharpInit.Tests/UnitRegistryTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpInit.Platform;
 using SharpInit.Units;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -131,6 +132,23 @@ namespace SharpInit.Tests
 
             // Assert
             Assert.IsTrue(UnitRegistry.Units.Count > 0);
+        }
+
+        [TestMethod]
+        public void GetUnitName_Checks()
+        {
+            var dictionary = new Dictionary<string, string>()
+            {
+                {"/home/user/.config/sharpinit/units/test@1001.service", "test.service" },
+                {"/etc/sharpinit/units/test@.service", "test.service" },
+                {"C:\\Users\\User\\.config\\sharpinit\\units\\notepad.service", "notepad.service" },
+                {"relative/path/to/sshd@22.service", "sshd.service" },
+                {"backslash\\relative\\path\\test.target", "test.target" }
+
+            };
+
+            foreach (var pair in dictionary)
+                Assert.AreEqual(UnitRegistry.GetUnitName(pair.Key), pair.Value);
         }
     }
 }

--- a/SharpInit/Platform/DefaultProcessHandler.cs
+++ b/SharpInit/Platform/DefaultProcessHandler.cs
@@ -48,8 +48,11 @@ namespace SharpInit.Platform
             if (Directory.Exists(psi.WorkingDirectory))
                 net_psi.WorkingDirectory = psi.WorkingDirectory;
 
-            net_psi.UserName = psi.User.Username;
-            net_psi.Domain = psi.User.Group;
+            if (psi.User != null)
+            {
+                net_psi.UserName = psi.User.Username;
+                net_psi.Domain = psi.User.Group;
+            }
 
             net_psi.RedirectStandardOutput = true;
             net_psi.RedirectStandardError = true;

--- a/SharpInit/Platform/GenericPlatformInitialization.cs
+++ b/SharpInit/Platform/GenericPlatformInitialization.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SharpInit.Units;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -12,7 +13,8 @@ namespace SharpInit.Platform
     {
         public void Initialize()
         {
-            // do nothing
+            UnitRegistry.InitializeTypes();
+            UnitRegistry.CreateBaseUnits();
         }
     }
 }

--- a/SharpInit/Platform/PlatformUtilities.cs
+++ b/SharpInit/Platform/PlatformUtilities.cs
@@ -56,7 +56,7 @@ namespace SharpInit.Platform
         }
 
         /// <summary>
-        /// Constructs an instance of the platform-specific class that implements T interface with the given parameters.
+        /// Constructs instances of all the platform-specific classes permitted by the current platform that implement interface T with the given parameters.
         /// </summary>
         /// <typeparam name="T">An interface that has multiple platform-specific implementations.</typeparam>
         /// <param name="constructor_params">The set of parameters to be passed to the constructor.</param>
@@ -67,13 +67,13 @@ namespace SharpInit.Platform
         }
 
         /// <summary>
-        /// Constructs an instance of the platform-specific class that implements T interface with the given parameters.
+        /// Constructs instances of all the platform-specific classes permitted by the PlatformIdentifier that implement T interface with the given parameters.
         /// </summary>
         /// <typeparam name="T">An interface that has multiple platform-specific implementations.</typeparam>
         /// <param name="id">The platform identifier to use when looking for the implementation.</param>
         /// <param name="constructor_params">The set of parameters to be passed to the constructor.</param>
-        /// <returns>A new instance of a class that implements T and matches the provided platform identifier.</returns>
-        public static T GetImplementation<T>(PlatformIdentifier id, params object[] constructor_params)
+        /// <returns>Classes that implement T and match the provided platform identifier.</returns>
+        public static IEnumerable<T> GetImplementations<T>(PlatformIdentifier id, params object[] constructor_params)
         {
             var T_type = typeof(T);
 
@@ -88,11 +88,12 @@ namespace SharpInit.Platform
                 foreach(var type in types)
                 {
                     if (PlatformsPerType[type].Contains(platform))
-                        return (T)Activator.CreateInstance(type, constructor_params);
+                        yield return (T)Activator.CreateInstance(type, constructor_params);
                 }
             }
-
-            throw new Exception();
         }
+
+        public static T GetImplementation<T>(PlatformIdentifier id, params object[] constructor_params) =>
+            GetImplementations<T>(id, constructor_params).FirstOrDefault();
     }
 }

--- a/SharpInit/Platform/Unix/UnixPlatformInitialization.cs
+++ b/SharpInit/Platform/Unix/UnixPlatformInitialization.cs
@@ -8,10 +8,11 @@ namespace SharpInit.Platform.Unix
     /// Unix platform initialization code. Sets up signals.
     /// </summary>
     [SupportedOn("unix")]
-    public class UnixPlatformInitialization : IPlatformInitialization
+    public class UnixPlatformInitialization : GenericPlatformInitialization
     {
-        public void Initialize()
+        public new void Initialize()
         {
+            base.Initialize();
             SignalHandler.Initialize();
         }
     }

--- a/SharpInit/Program.cs
+++ b/SharpInit/Program.cs
@@ -23,7 +23,6 @@ namespace SharpInit
 
             Log.Info("Platform initialization complete");
 
-            UnitRegistry.InitializeTypes();
             UnitRegistry.ScanDefaultDirectories();
             
             Log.Info($"Loaded {UnitRegistry.Units.Count} units");

--- a/SharpInit/ServerIpcContext.cs
+++ b/SharpInit/ServerIpcContext.cs
@@ -80,11 +80,16 @@ namespace SharpInit
             return UnitRegistry.Units.Select(u => u.Key).ToList();
         }
 
+        public List<string> ListUnitFiles()
+        {
+            return UnitRegistry.UnitFiles.Select(p => string.Join(", ", p.Value.Select(t => t.ToString()))).ToList();
+        }
+
         public bool LoadUnitFromFile(string path)
         {
             try
             {
-                UnitRegistry.AddUnitByPath(path);
+                UnitRegistry.IndexUnitFile(path);
                 return true;
             }
             catch { return false; }
@@ -106,9 +111,11 @@ namespace SharpInit
             var unit = UnitRegistry.GetUnit(unit_name);
             var info = new UnitInfo();
 
+            var unit_files = unit.Descriptor.Files.OfType<OnDiskUnitFile>();
+
             info.Name = unit.UnitName;
-            info.Path = unit.Descriptor.Files.Any(f => f is OnDiskUnitFile) ? 
-                (unit.Descriptor.Files.First(f => f is OnDiskUnitFile) as OnDiskUnitFile).Path :
+            info.Path = unit_files.Any() ? 
+                string.Join(", ", unit_files.Select(file => file.Path)) :
                 "(not available)";
             info.Description = unit.Descriptor.Description;
             info.State = Enum.Parse<Ipc.UnitState>(unit.CurrentState.ToString());

--- a/SharpInit/ServerIpcContext.cs
+++ b/SharpInit/ServerIpcContext.cs
@@ -92,7 +92,7 @@ namespace SharpInit
 
         public bool ReloadUnitFile(string unit)
         {
-            UnitRegistry.GetUnit(unit).ReloadUnitFile();
+            UnitRegistry.GetUnit(unit).ReloadUnitDescriptor();
             return true;
         }
 
@@ -107,8 +107,10 @@ namespace SharpInit
             var info = new UnitInfo();
 
             info.Name = unit.UnitName;
-            info.Path = unit.File.UnitPath;
-            info.Description = unit.File.Description;
+            info.Path = unit.Descriptor.Files.Any(f => f is OnDiskUnitFile) ? 
+                (unit.Descriptor.Files.First(f => f is OnDiskUnitFile) as OnDiskUnitFile).Path :
+                "(not available)";
+            info.Description = unit.Descriptor.Description;
             info.State = Enum.Parse<Ipc.UnitState>(unit.CurrentState.ToString());
             info.LastStateChangeTime = unit.LastStateChangeTime;
             info.ActivationTime = unit.ActivationTime;

--- a/SharpInit/ServerIpcContext.cs
+++ b/SharpInit/ServerIpcContext.cs
@@ -89,7 +89,7 @@ namespace SharpInit
         {
             try
             {
-                UnitRegistry.IndexUnitFile(path);
+                UnitRegistry.IndexUnitByPath(path);
                 return true;
             }
             catch { return false; }
@@ -121,7 +121,7 @@ namespace SharpInit
             info.State = Enum.Parse<Ipc.UnitState>(unit.CurrentState.ToString());
             info.LastStateChangeTime = unit.LastStateChangeTime;
             info.ActivationTime = unit.ActivationTime;
-            info.LoadTime = unit.LoadTime;
+            info.LoadTime = unit.Descriptor.Created;
 
             return info;
         }

--- a/SharpInit/SharpInit.csproj
+++ b/SharpInit/SharpInit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>0.1</Version>
   </PropertyGroup>
 

--- a/SharpInit/StringEscaper.cs
+++ b/SharpInit/StringEscaper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SharpInit
+{
+    public static class StringEscaper
+    {
+        public static string Escape(string input, bool path = false)
+        {
+            if (path)
+                input = Path.GetFullPath(input);
+
+            input = input.Replace('/', '-');
+
+            StringBuilder new_output = new StringBuilder();
+
+            for(int i = 0; i < input.Length; i++)
+            {
+                var original_char = input[i];
+
+                if (!char.IsLetterOrDigit(original_char) && original_char != '_' ||
+                    (i == 0 && original_char == '.')) // escape '.' if it's the first char in the string
+                    new_output.Append($"\\x{Convert.ToString((int)original_char, 16)}");
+                else
+                    new_output.Append(original_char);
+            }
+
+            return new_output.ToString();
+        }
+
+        public static string Unescape(string input, bool path = false)
+        {
+            input = input.Replace('-', '/');
+
+            StringBuilder new_output = new StringBuilder();
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                var original_char = input[i];
+
+                if (!char.IsLetterOrDigit(original_char) && original_char != '_' ||
+                    (i == 0 && original_char == '.')) // escape '.' if it's the first char in the string
+                    new_output.Append($"\\x{Convert.ToString((int)original_char, 16)}");
+                else
+                    new_output.Append(original_char);
+            }
+
+            return new_output.ToString();
+        }
+    }
+}

--- a/SharpInit/StringEscaper.cs
+++ b/SharpInit/StringEscaper.cs
@@ -40,10 +40,6 @@ namespace SharpInit
             {
                 var original_char = input[i];
 
-                if (!char.IsLetterOrDigit(original_char) && original_char != '_' ||
-                    (i == 0 && original_char == '.')) // escape '.' if it's the first char in the string
-                    new_output.Append($"\\x{Convert.ToString((int)original_char, 16)}");
-                else
                     new_output.Append(original_char);
             }
 

--- a/SharpInit/Tasks/StopProcessTask.cs
+++ b/SharpInit/Tasks/StopProcessTask.cs
@@ -40,7 +40,7 @@ namespace SharpInit.Tasks
             }
             else
             {
-                ProcessInfo.Process.Kill();
+                ProcessInfo.Process.Kill(true);
             }
 
             return new TaskResult(this, ResultType.Success);

--- a/SharpInit/Units/ExecUnitDescriptor.cs
+++ b/SharpInit/Units/ExecUnitDescriptor.cs
@@ -7,7 +7,7 @@ namespace SharpInit.Units
     /// <summary>
     /// Common denominator unit type for .service, .socket, .swap and .mount
     /// </summary>
-    public class ExecUnitFile : UnitFile
+    public class ExecUnitDescriptor : UnitDescriptor
     {
         [UnitProperty("@/WorkingDirectory", UnitPropertyType.String)]
         public string WorkingDirectory { get; set; }

--- a/SharpInit/Units/ServiceUnit.cs
+++ b/SharpInit/Units/ServiceUnit.cs
@@ -17,8 +17,8 @@ namespace SharpInit.Units
 
         public int COMMAND_TIMEOUT = 5000;
 
-        public ServiceUnit(ServiceUnitDescriptor desc) :
-            base(desc)
+        public ServiceUnit(string name, ServiceUnitDescriptor desc) :
+            base(name, desc)
         {
             ProcessStart += HandleProcessStart;
             ProcessExit += HandleProcessExit;
@@ -141,9 +141,9 @@ namespace SharpInit.Units
 
             transaction.Add(new SetUnitStateTask(this, UnitState.Deactivating, UnitState.Active));
             transaction.Add(new StopUnitProcessesTask(this));
-            transaction.Add(new SetUnitStateTask(this, UnitState.Inactive, UnitState.Deactivating));
+            //transaction.Add(new SetUnitStateTask(this, UnitState.Inactive, UnitState.Deactivating));
 
-            transaction.OnFailure = new SetUnitStateTask(this, UnitState.Inactive);
+            transaction.OnFailure = new SetUnitStateTask(this, UnitState.Failed);
 
             return transaction;
         }

--- a/SharpInit/Units/ServiceUnit.cs
+++ b/SharpInit/Units/ServiceUnit.cs
@@ -30,6 +30,9 @@ namespace SharpInit.Units
             ProcessExit += HandleProcessExit;
         }
 
+        public override UnitDescriptor GetUnitDescriptor() => Descriptor;
+        public override void SetUnitDescriptor(UnitDescriptor desc) => Descriptor = (ServiceUnitDescriptor)desc;
+
         private void HandleProcessExit(Unit unit, ProcessInfo info, int code)
         {
             switch(CurrentState)

--- a/SharpInit/Units/ServiceUnit.cs
+++ b/SharpInit/Units/ServiceUnit.cs
@@ -13,12 +13,18 @@ namespace SharpInit.Units
     {
         Logger Log = LogManager.GetCurrentClassLogger();
 
-        public new ServiceUnitFile File { get; set; }
-        public override UnitFile GetUnitFile() => (UnitFile)File;
+        public new ServiceUnitDescriptor Descriptor { get; set; }
 
         public int COMMAND_TIMEOUT = 5000;
 
-        public ServiceUnit(string path) : base(path)
+        public ServiceUnit(ServiceUnitDescriptor desc) :
+            base(desc)
+        {
+            ProcessStart += HandleProcessStart;
+            ProcessExit += HandleProcessExit;
+        }
+
+        public ServiceUnit() : base()
         {
             ProcessStart += HandleProcessStart;
             ProcessExit += HandleProcessExit;
@@ -46,18 +52,18 @@ namespace SharpInit.Units
 
                     if (code == 0)
                         should_restart =
-                            File.Restart == RestartBehavior.Always ||
-                            File.Restart == RestartBehavior.OnSuccess;
+                            Descriptor.Restart == RestartBehavior.Always ||
+                            Descriptor.Restart == RestartBehavior.OnSuccess;
                     else
                         should_restart =
-                            File.Restart == RestartBehavior.Always ||
-                            File.Restart == RestartBehavior.OnFailure ||
-                            File.Restart == RestartBehavior.OnAbnormal;
+                            Descriptor.Restart == RestartBehavior.Always ||
+                            Descriptor.Restart == RestartBehavior.OnFailure ||
+                            Descriptor.Restart == RestartBehavior.OnAbnormal;
 
                     if(should_restart)
                     {
                         var restart_transaction = new Transaction(
-                            new DelayTask(File.RestartSec),
+                            new DelayTask(Descriptor.RestartSec),
                             UnitRegistry.CreateDeactivationTransaction(UnitName),
                             UnitRegistry.CreateActivationTransaction(UnitName));
 
@@ -73,59 +79,47 @@ namespace SharpInit.Units
             // do nothing for now
         }
 
-        public override void LoadUnitFile(string path)
-        {
-            File = UnitParser.Parse<ServiceUnitFile>(path);
-            LoadTime = DateTime.UtcNow;
-        }
-
-        public override void LoadUnitFile(UnitFile file)
-        {
-            File = (ServiceUnitFile)file;
-            LoadTime = DateTime.UtcNow;
-        }
-
         internal override Transaction GetActivationTransaction()
         {
             var transaction = new Transaction($"Activation transaction for unit {UnitName}");
             transaction.Add(new SetUnitStateTask(this, UnitState.Activating, UnitState.Inactive | UnitState.Failed));
 
-            var working_dir = File.WorkingDirectory;
-            var user = (File.Group == null && File.User == null ? null : PlatformUtilities.GetImplementation<IUserIdentifier>(File.Group, File.User));
+            var working_dir = Descriptor.WorkingDirectory;
+            var user = (Descriptor.Group == null && Descriptor.User == null ? null : PlatformUtilities.GetImplementation<IUserIdentifier>(Descriptor.Group, Descriptor.User));
 
-            switch (File.ServiceType)
+            switch (Descriptor.ServiceType)
             {
                 case ServiceType.Simple:
-                    if (File.ExecStart == null)
+                    if (Descriptor.ExecStart == null)
                     {
                         Log.Error($"Unit {UnitName} has no ExecStart directives.");
                         SetState(UnitState.Failed);
                         return null;
                     }
 
-                    if (File.ExecStart.Count != 1)
+                    if (Descriptor.ExecStart.Count != 1)
                     {
-                        Log.Error($"Service type \"simple\" only supports one ExecStart value, {UnitName} has {File.ExecStart.Count}");
+                        Log.Error($"Service type \"simple\" only supports one ExecStart value, {UnitName} has {Descriptor.ExecStart.Count}");
                         SetState(UnitState.Failed);
                         return null;
                     }
 
-                    if (File.ExecStartPre.Any())
+                    if (Descriptor.ExecStartPre.Any())
                     {
-                        foreach (var line in File.ExecStartPre)
+                        foreach (var line in Descriptor.ExecStartPre)
                             transaction.Add(new RunUnregisteredProcessTask(ServiceManager.ProcessHandler, ProcessStartInfo.FromCommandLine(line, working_dir, user), 5000));
                     }
 
-                    transaction.Add(new RunRegisteredProcessTask(ProcessStartInfo.FromCommandLine(File.ExecStart.Single(), working_dir, user), this));
+                    transaction.Add(new RunRegisteredProcessTask(ProcessStartInfo.FromCommandLine(Descriptor.ExecStart.Single(), working_dir, user), this));
 
-                    if (File.ExecStartPost.Any())
+                    if (Descriptor.ExecStartPost.Any())
                     {
-                        foreach (var line in File.ExecStartPost)
+                        foreach (var line in Descriptor.ExecStartPost)
                             transaction.Add(new RunUnregisteredProcessTask(ServiceManager.ProcessHandler, ProcessStartInfo.FromCommandLine(line, working_dir, user), 5000));
                     }
                     break;
                 default:
-                    Log.Error($"Only the \"simple\" service type is supported for now, {UnitName} has type {File.ServiceType}");
+                    Log.Error($"Only the \"simple\" service type is supported for now, {UnitName} has type {Descriptor.ServiceType}");
                     SetState(UnitState.Failed);
                     break;
             }
@@ -156,15 +150,15 @@ namespace SharpInit.Units
             var transaction = new Transaction();
             transaction.Add(new SetUnitStateTask(this, UnitState.Reloading, UnitState.Active));
 
-            var working_dir = File.WorkingDirectory;
-            var user = (File.Group == null && File.User == null ? null : PlatformUtilities.GetImplementation<IUserIdentifier>(File.Group, File.User));
+            var working_dir = Descriptor.WorkingDirectory;
+            var user = (Descriptor.Group == null && Descriptor.User == null ? null : PlatformUtilities.GetImplementation<IUserIdentifier>(Descriptor.Group, Descriptor.User));
 
-            if (!File.ExecReload.Any())
+            if (!Descriptor.ExecReload.Any())
             {
                 throw new Exception($"Unit {UnitName} has no ExecReload directives.");
             }
             
-            foreach(var reload_cmd in File.ExecReload)
+            foreach(var reload_cmd in Descriptor.ExecReload)
             {
                 transaction.Add(new RunUnregisteredProcessTask(ServiceManager.ProcessHandler, ProcessStartInfo.FromCommandLine(reload_cmd, working_dir, user), 5000));
             }

--- a/SharpInit/Units/ServiceUnitDescriptor.cs
+++ b/SharpInit/Units/ServiceUnitDescriptor.cs
@@ -47,7 +47,7 @@ namespace SharpInit.Units
         public List<string> ExecReload { get; set; }
         #endregion
 
-        public ServiceUnitDescriptor() { }
+        public ServiceUnitDescriptor() : base() { }
     }
 
     public enum RestartBehavior

--- a/SharpInit/Units/ServiceUnitDescriptor.cs
+++ b/SharpInit/Units/ServiceUnitDescriptor.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace SharpInit.Units
 {
-    public class ServiceUnitFile : ExecUnitFile
+    public class ServiceUnitDescriptor : ExecUnitDescriptor
     {
         [UnitProperty("Service/Type", UnitPropertyType.Enum, ServiceType.Simple, typeof(ServiceType))]
         public ServiceType ServiceType { get; set; }
@@ -47,8 +47,7 @@ namespace SharpInit.Units
         public List<string> ExecReload { get; set; }
         #endregion
 
-        public ServiceUnitFile() { }
-        public ServiceUnitFile(string path) => UnitParser.Parse<ServiceUnitFile>(path);
+        public ServiceUnitDescriptor() { }
     }
 
     public enum RestartBehavior

--- a/SharpInit/Units/TargetUnit.cs
+++ b/SharpInit/Units/TargetUnit.cs
@@ -12,8 +12,8 @@ namespace SharpInit.Units
         
         public new UnitDescriptor Descriptor { get; set; }
 
-        public TargetUnit(UnitDescriptor descriptor) 
-            : base(descriptor)
+        public TargetUnit(string name, UnitDescriptor descriptor) 
+            : base(name, descriptor)
         {
 
         }

--- a/SharpInit/Units/TargetUnit.cs
+++ b/SharpInit/Units/TargetUnit.cs
@@ -10,11 +10,16 @@ namespace SharpInit.Units
     {
         Logger Log = LogManager.GetCurrentClassLogger();
         
+        public new UnitDescriptor Descriptor { get; set; }
+
         public TargetUnit(UnitDescriptor descriptor) 
             : base(descriptor)
         {
 
         }
+
+        public override UnitDescriptor GetUnitDescriptor() => Descriptor;
+        public override void SetUnitDescriptor(UnitDescriptor desc) => Descriptor = desc;
 
         internal override Transaction GetActivationTransaction()
         {

--- a/SharpInit/Units/TargetUnit.cs
+++ b/SharpInit/Units/TargetUnit.cs
@@ -9,25 +9,11 @@ namespace SharpInit.Units
     public class TargetUnit : Unit
     {
         Logger Log = LogManager.GetCurrentClassLogger();
-
-        public new UnitFile File { get; set; }
-        public override UnitFile GetUnitFile() => File;
-
-        public TargetUnit(string path) : base(path)
-        {
-
-        }
         
-        public override void LoadUnitFile(string path)
+        public TargetUnit(UnitDescriptor descriptor) 
+            : base(descriptor)
         {
-            File = UnitParser.Parse<UnitFile>(path);
-            LoadTime = DateTime.UtcNow;
-        }
 
-        public override void LoadUnitFile(UnitFile file)
-        {
-            File = file;
-            LoadTime = DateTime.UtcNow;
         }
 
         internal override Transaction GetActivationTransaction()

--- a/SharpInit/Units/Unit.cs
+++ b/SharpInit/Units/Unit.cs
@@ -30,25 +30,12 @@ namespace SharpInit.Units
 
         private DependencyGraph<RequirementDependency> RequirementDependencyGraph { get; set; }
         private DependencyGraph<OrderingDependency> OrderingDependencyGraph { get; set; }
-        
-        //protected Unit(UnitFile file)
-        //{
-            
-        //}
 
-        //protected Unit(string path)
-        //{
-        //    LoadUnitFile(path);
-        //    UnitName = File.UnitName;
-        //}
-
-        protected Unit(UnitDescriptor descriptor)
+        protected Unit(string name, UnitDescriptor descriptor)
             : this()
         {
+            UnitName = name;
             Descriptor = descriptor;
-
-            if (Descriptor?.Files?.Any() == true)
-                UnitName = UnitRegistry.GetUnitName((Descriptor.Files.FirstOrDefault(f => f is OnDiskUnitFile) as OnDiskUnitFile)?.Path ?? "unknown.unit");
         }
 
         protected Unit()

--- a/SharpInit/Units/Unit.cs
+++ b/SharpInit/Units/Unit.cs
@@ -16,7 +16,7 @@ namespace SharpInit.Units
         public string UnitName { get; set; }
         public UnitState CurrentState { get; internal set; }
 
-        public UnitDescriptor Descriptor { get; set; }
+        public UnitDescriptor Descriptor { get => GetUnitDescriptor(); set => SetUnitDescriptor(value); }
 
         public ServiceManager ServiceManager { get; set; }
 
@@ -48,14 +48,15 @@ namespace SharpInit.Units
             Descriptor = descriptor;
 
             if (Descriptor?.Files?.Any() == true)
-                UnitName = (Descriptor.Files.FirstOrDefault(f => f is OnDiskUnitFile) as OnDiskUnitFile)?.Path ?? "unknown.unit";
+                UnitName = UnitRegistry.GetUnitName((Descriptor.Files.FirstOrDefault(f => f is OnDiskUnitFile) as OnDiskUnitFile)?.Path ?? "unknown.unit");
         }
 
         protected Unit()
         {
         }
 
-        //public abstract UnitFile GetUnitFile();
+        public abstract UnitDescriptor GetUnitDescriptor();
+        public abstract void SetUnitDescriptor(UnitDescriptor desc);
         //public abstract void LoadUnitFile(string path);
         //public abstract void LoadUnitFile(UnitFile file);
 
@@ -81,7 +82,8 @@ namespace SharpInit.Units
 
         public void ReloadUnitDescriptor()
         {
-            throw new NotImplementedException();
+            var new_descriptor = UnitParser.FromFiles(Descriptor.GetType(), Descriptor.Files.Select(file => file is OnDiskUnitFile ? UnitParser.ParseFile((file as OnDiskUnitFile).Path) : file).ToArray());
+            Descriptor = new_descriptor;
         }
 
         internal void RaiseProcessExit(ProcessInfo proc, int exit_code)

--- a/SharpInit/Units/UnitDescriptor.cs
+++ b/SharpInit/Units/UnitDescriptor.cs
@@ -141,9 +141,11 @@ namespace SharpInit.Units
         public Dictionary<string, List<string>> Assertions = new Dictionary<string, List<string>>();
         #endregion
         
+        public DateTime Created { get; set; }
+
         public UnitDescriptor()
         {
-
+            Created = DateTime.UtcNow;
         }
     }
 

--- a/SharpInit/Units/UnitDescriptor.cs
+++ b/SharpInit/Units/UnitDescriptor.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace SharpInit.Units
+{
+    public class UnitDescriptor
+    {
+        public IEnumerable<UnitFile> Files { get; set; }
+
+        #region Base properties
+        [UnitProperty("Unit/Description")]
+        public string Description { get; set; }
+
+        [UnitProperty("Unit/SourcePath")]
+        public string SourcePath { get; set; }
+
+        [UnitProperty("Unit/Documentation", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> Documentation { get; set; }
+        #endregion
+
+        #region Dependency properties
+        [UnitProperty("Unit/Requires", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> Requires { get; set; }
+
+        [UnitProperty("Unit/Requisite", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> Requisite { get; set; }
+        
+        [UnitProperty("Unit/Wants", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> Wants { get; set; }
+        
+        [UnitProperty("Unit/BindsTo", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> BindsTo { get; set; }
+
+        [UnitProperty("Unit/PartOf", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> PartOf { get; set; }
+
+        [UnitProperty("Unit/Conflicts", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> Conflicts { get; set; }
+
+        [UnitProperty("Unit/Before", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> Before { get; set; }
+
+        [UnitProperty("Unit/After", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> After { get; set; }
+        
+        [UnitProperty("Unit/PropagatesReloadTo", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> PropagatesReloadTo { get; set; }
+        
+        [UnitProperty("Unit/ReloadPropagatedFrom", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> ReloadPropagatedFrom { get; set; }
+        
+        [UnitProperty("Unit/JoinsNamespaceOf", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> JoinsNamespaceOf { get; set; }
+        
+        [UnitProperty("Unit/RequiresMountsFor", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> RequiresMountsFor { get; set; }
+        
+        [UnitProperty("Unit/DefaultDependencies", UnitPropertyType.Bool, true)]
+        public bool DefaultDependencies { get; set; }
+        #endregion
+
+        #region Isolation properties
+        [UnitProperty("Unit/AllowIsolate", UnitPropertyType.Bool, false)]
+        public bool AllowIsolate { get; set; }
+
+        [UnitProperty("Unit/IgnoreOnIsolate", UnitPropertyType.Bool)]
+        public bool IgnoreOnIsolate { get; set; }
+        #endregion
+
+        #region Start/stop properties
+        [UnitProperty("Unit/StopWhenUnneeded", UnitPropertyType.Bool, false)]
+        public bool StopWhenUnneeded { get; set; }
+
+        [UnitProperty("Unit/RefuseManualStart", UnitPropertyType.Bool, false)]
+        public bool RefuseManualStart { get; set; }
+
+        [UnitProperty("Unit/RefuseManualStop", UnitPropertyType.Bool, false)]
+        public bool RefuseManualStop { get; set; }
+        #endregion
+
+        #region Failure, success, and collection properties
+        [UnitProperty("Unit/OnFailureJobMode", UnitPropertyType.Enum, OnFailureJobMode.Replace, typeof(OnFailureJobMode))]
+        public OnFailureJobMode OnFailureJobMode { get; set; }
+
+        [UnitProperty("Unit/CollectMode", UnitPropertyType.Enum, CollectMode.Inactive, typeof(CollectMode))]
+        public CollectMode CollectMode { get; set; }
+
+        [UnitProperty("Unit/FailureAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
+        public FailureOrSuccessAction FailureAction { get; set; }
+
+        [UnitProperty("Unit/SuccessAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
+        public FailureOrSuccessAction SuccessAction { get; set; }
+
+        [UnitProperty("Unit/RebootArgument", UnitPropertyType.String)]
+        public string RebootArgument { get; set; }
+
+        [UnitProperty("Unit/FailureActionExitStatus", UnitPropertyType.Int, -1)]
+        public int FailureActionExitStatus { get; set; }
+
+        [UnitProperty("Unit/SuccessActionExitStatus", UnitPropertyType.Int, -1)]
+        public int SuccessActionExitStatus { get; set; }
+
+        #endregion
+
+        #region Timeout properties
+        [UnitProperty("Unit/JobTimeoutSec", UnitPropertyType.Int, -1)]
+        public int JobTimeoutSec { get; set; }
+
+        [UnitProperty("Unit/JobRunningTimeoutSec", UnitPropertyType.Int, -1)]
+        public int JobRunningTimeoutSec { get; set; }
+
+        [UnitProperty("Unit/JobTimeoutAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
+        public FailureOrSuccessAction JobTimeoutAction { get; set; }
+
+        [UnitProperty("Unit/JobTimeoutRebootArgument", UnitPropertyType.String)]
+        public string JobTimeoutRebootArgument { get; set; }
+        #endregion
+
+        #region Limiting properties
+        [UnitProperty("Unit/StartLimitIntervalSec", UnitPropertyType.Int, -1)]
+        public int StartLimitIntervalSec { get; set; }
+
+        [UnitProperty("Unit/StartLimitBurst", UnitPropertyType.Int, -1)]
+        public int StartLimitBurst { get; set; }
+
+        [UnitProperty("Unit/StartLimitAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
+        public FailureOrSuccessAction StartLimitAction { get; set; }
+        #endregion
+
+        #region Condition/assertion properties
+        // TODO: Use a better method for this
+        // These currently map the vast amount of conditions/assertions supported by systemd into
+        // dictionaries.
+        //
+        // Example: ConditionPathExists=!/usr/bin will be mapped to: 
+        // Conditions["PathExists"] = { "!/usr/bin" } (shortened for brevity)
+        public Dictionary<string, List<string>> Conditions = new Dictionary<string, List<string>>();
+        public Dictionary<string, List<string>> Assertions = new Dictionary<string, List<string>>();
+        #endregion
+        
+        public UnitDescriptor()
+        {
+
+        }
+    }
+
+    public enum OnFailureJobMode
+    {
+        Fail,
+        Replace,
+        ReplaceIrreversibly,
+        Isolate,
+        Flush,
+        IgnoreDependencies,
+        IgnoreRequirements
+    }
+
+    public enum CollectMode
+    {
+        Inactive,
+        InactiveOrFailed
+    }
+
+    public enum FailureOrSuccessAction
+    {
+        None,
+        Reboot,
+        RebootForce,
+        RebootImmediate,
+        Poweroff,
+        PoweroffForce,
+        PoweroffImmediate,
+        Exit,
+        ExitForce
+    }
+}

--- a/SharpInit/Units/UnitDescriptor.cs
+++ b/SharpInit/Units/UnitDescriptor.cs
@@ -119,6 +119,14 @@ namespace SharpInit.Units
         public string JobTimeoutRebootArgument { get; set; }
         #endregion
 
+        #region Install section
+        [UnitProperty("Install/DefaultInstance")]
+        public string DefaultInstance { get; set; }
+
+        [UnitProperty("Install/WantedBy", UnitPropertyType.StringListSpaceSeparated)]
+        public List<string> WantedBy { get; set; }
+        #endregion
+
         #region Limiting properties
         [UnitProperty("Unit/StartLimitIntervalSec", UnitPropertyType.Int, -1)]
         public int StartLimitIntervalSec { get; set; }

--- a/SharpInit/Units/UnitDescriptor.cs
+++ b/SharpInit/Units/UnitDescriptor.cs
@@ -147,6 +147,29 @@ namespace SharpInit.Units
         {
             Created = DateTime.UtcNow;
         }
+
+        internal void InstantiateDescriptor(UnitInstantiationContext ctx)
+        {
+            var self_properties = this.GetType().GetProperties();
+            var properties_with_attribute = self_properties.Where(prop => prop.GetCustomAttributes(typeof(UnitPropertyAttribute), true).Any());
+
+            foreach (var property in properties_with_attribute)
+            {
+                switch (property.GetValue(this))
+                {
+                    case string str:
+                        property.SetValue(this, ctx.Substitute(str));
+                        break;
+                    case List<string> list:
+                        for (int i = 0; i < list.Count; i++)
+                        {
+                            list[i] = ctx.Substitute(list[i]);
+                        }
+                        break;
+
+                }
+            }
+        }
     }
 
     public enum OnFailureJobMode

--- a/SharpInit/Units/UnitFile.cs
+++ b/SharpInit/Units/UnitFile.cs
@@ -1,13 +1,34 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.IO;
 
 namespace SharpInit.Units
 {
     public abstract class UnitFile
     {
         public Dictionary<string, List<string>> Properties { get; set; }
+
+        public string UnitName { get; set; }
         public string Extension { get; set; }
+    }
+
+    public class GeneratedUnitFile : UnitFile
+    {
+        public GeneratedUnitFile(string name)
+        {
+            Properties = new Dictionary<string, List<string>>();
+            UnitName = name;
+            Extension = Path.GetExtension(name);
+        }
+
+        public GeneratedUnitFile WithProperty(string name, string value)
+        {
+            if (!Properties.ContainsKey(name))
+                Properties[name] = new List<string>();
+
+            Properties[name].Add(value);
+            return this;
+        }
     }
 
     public class OnDiskUnitFile : UnitFile
@@ -17,7 +38,8 @@ namespace SharpInit.Units
         public OnDiskUnitFile(string path)
         {
             Path = path;
-            Extension = System.IO.Path.GetExtension(path);
+            UnitName = UnitRegistry.GetUnitName(path);
+            Extension = System.IO.Path.GetExtension(UnitName);
         }
 
         public override string ToString()

--- a/SharpInit/Units/UnitFile.cs
+++ b/SharpInit/Units/UnitFile.cs
@@ -8,7 +8,6 @@ namespace SharpInit.Units
     {
         public Dictionary<string, List<string>> Properties { get; set; }
         public string Extension { get; set; }
-        
     }
 
     public class OnDiskUnitFile : UnitFile
@@ -19,6 +18,11 @@ namespace SharpInit.Units
         {
             Path = path;
             Extension = System.IO.Path.GetExtension(path);
+        }
+
+        public override string ToString()
+        {
+            return $"Unit file loaded from \"{Path}\"";
         }
     }
 }

--- a/SharpInit/Units/UnitFile.cs
+++ b/SharpInit/Units/UnitFile.cs
@@ -1,184 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace SharpInit.Units
 {
-    public class UnitFile
+    public abstract class UnitFile
     {
-        public string UnitPath { get; set; }
-        public string UnitName { get; set; }
-
-        // Most of these properties are either half-complete or completely unsupported so far, but you gotta walk before you run
-
         public Dictionary<string, List<string>> Properties { get; set; }
-
-        #region Base properties
-        [UnitProperty("Unit/Description")]
-        public string Description { get; set; }
-
-        [UnitProperty("Unit/SourcePath")]
-        public string SourcePath { get; set; }
-
-        [UnitProperty("Unit/Documentation", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> Documentation { get; set; }
-        #endregion
-
-        #region Dependency properties
-        [UnitProperty("Unit/Requires", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> Requires { get; set; }
-
-        [UnitProperty("Unit/Requisite", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> Requisite { get; set; }
+        public string Extension { get; set; }
         
-        [UnitProperty("Unit/Wants", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> Wants { get; set; }
-        
-        [UnitProperty("Unit/BindsTo", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> BindsTo { get; set; }
+    }
 
-        [UnitProperty("Unit/PartOf", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> PartOf { get; set; }
+    public class OnDiskUnitFile : UnitFile
+    {
+        public string Path { get; set; }
 
-        [UnitProperty("Unit/Conflicts", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> Conflicts { get; set; }
-
-        [UnitProperty("Unit/Before", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> Before { get; set; }
-
-        [UnitProperty("Unit/After", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> After { get; set; }
-        
-        [UnitProperty("Unit/PropagatesReloadTo", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> PropagatesReloadTo { get; set; }
-        
-        [UnitProperty("Unit/ReloadPropagatedFrom", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> ReloadPropagatedFrom { get; set; }
-        
-        [UnitProperty("Unit/JoinsNamespaceOf", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> JoinsNamespaceOf { get; set; }
-        
-        [UnitProperty("Unit/RequiresMountsFor", UnitPropertyType.StringListSpaceSeparated)]
-        public List<string> RequiresMountsFor { get; set; }
-        
-        [UnitProperty("Unit/DefaultDependencies", UnitPropertyType.Bool, true)]
-        public bool DefaultDependencies { get; set; }
-        #endregion
-
-        #region Isolation properties
-        [UnitProperty("Unit/AllowIsolate", UnitPropertyType.Bool, false)]
-        public bool AllowIsolate { get; set; }
-
-        [UnitProperty("Unit/IgnoreOnIsolate", UnitPropertyType.Bool)]
-        public bool IgnoreOnIsolate { get; set; }
-        #endregion
-
-        #region Start/stop properties
-        [UnitProperty("Unit/StopWhenUnneeded", UnitPropertyType.Bool, false)]
-        public bool StopWhenUnneeded { get; set; }
-
-        [UnitProperty("Unit/RefuseManualStart", UnitPropertyType.Bool, false)]
-        public bool RefuseManualStart { get; set; }
-
-        [UnitProperty("Unit/RefuseManualStop", UnitPropertyType.Bool, false)]
-        public bool RefuseManualStop { get; set; }
-        #endregion
-
-        #region Failure, success, and collection properties
-        [UnitProperty("Unit/OnFailureJobMode", UnitPropertyType.Enum, OnFailureJobMode.Replace, typeof(OnFailureJobMode))]
-        public OnFailureJobMode OnFailureJobMode { get; set; }
-
-        [UnitProperty("Unit/CollectMode", UnitPropertyType.Enum, CollectMode.Inactive, typeof(CollectMode))]
-        public CollectMode CollectMode { get; set; }
-
-        [UnitProperty("Unit/FailureAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
-        public FailureOrSuccessAction FailureAction { get; set; }
-
-        [UnitProperty("Unit/SuccessAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
-        public FailureOrSuccessAction SuccessAction { get; set; }
-
-        [UnitProperty("Unit/RebootArgument", UnitPropertyType.String)]
-        public string RebootArgument { get; set; }
-
-        [UnitProperty("Unit/FailureActionExitStatus", UnitPropertyType.Int, -1)]
-        public int FailureActionExitStatus { get; set; }
-
-        [UnitProperty("Unit/SuccessActionExitStatus", UnitPropertyType.Int, -1)]
-        public int SuccessActionExitStatus { get; set; }
-
-        #endregion
-
-        #region Timeout properties
-        [UnitProperty("Unit/JobTimeoutSec", UnitPropertyType.Int, -1)]
-        public int JobTimeoutSec { get; set; }
-
-        [UnitProperty("Unit/JobRunningTimeoutSec", UnitPropertyType.Int, -1)]
-        public int JobRunningTimeoutSec { get; set; }
-
-        [UnitProperty("Unit/JobTimeoutAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
-        public FailureOrSuccessAction JobTimeoutAction { get; set; }
-
-        [UnitProperty("Unit/JobTimeoutRebootArgument", UnitPropertyType.String)]
-        public string JobTimeoutRebootArgument { get; set; }
-        #endregion
-
-        #region Limiting properties
-        [UnitProperty("Unit/StartLimitIntervalSec", UnitPropertyType.Int, -1)]
-        public int StartLimitIntervalSec { get; set; }
-
-        [UnitProperty("Unit/StartLimitBurst", UnitPropertyType.Int, -1)]
-        public int StartLimitBurst { get; set; }
-
-        [UnitProperty("Unit/StartLimitAction", UnitPropertyType.Enum, FailureOrSuccessAction.None, typeof(FailureOrSuccessAction))]
-        public FailureOrSuccessAction StartLimitAction { get; set; }
-        #endregion
-
-        #region Condition/assertion properties
-        // TODO: Use a better method for this
-        // These currently map the vast amount of conditions/assertions supported by systemd into
-        // dictionaries.
-        //
-        // Example: ConditionPathExists=!/usr/bin will be mapped to: 
-        // Conditions["PathExists"] = { "!/usr/bin" } (shortened for brevity)
-        public Dictionary<string, List<string>> Conditions = new Dictionary<string, List<string>>();
-        public Dictionary<string, List<string>> Assertions = new Dictionary<string, List<string>>();
-        #endregion
-        
-        public UnitFile()
+        public OnDiskUnitFile(string path)
         {
-
+            Path = path;
+            Extension = System.IO.Path.GetExtension(path);
         }
-    }
-
-    public enum OnFailureJobMode
-    {
-        Fail,
-        Replace,
-        ReplaceIrreversibly,
-        Isolate,
-        Flush,
-        IgnoreDependencies,
-        IgnoreRequirements
-    }
-
-    public enum CollectMode
-    {
-        Inactive,
-        InactiveOrFailed
-    }
-
-    public enum FailureOrSuccessAction
-    {
-        None,
-        Reboot,
-        RebootForce,
-        RebootImmediate,
-        Poweroff,
-        PoweroffForce,
-        PoweroffImmediate,
-        Exit,
-        ExitForce
     }
 }

--- a/SharpInit/Units/UnitInstantiationContext.cs
+++ b/SharpInit/Units/UnitInstantiationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace SharpInit.Units
@@ -9,5 +10,22 @@ namespace SharpInit.Units
         public Dictionary<string, string> Substitutions { get; set; }
 
         public UnitInstantiationContext() { Substitutions = new Dictionary<string, string>(); }
+
+        public string Substitute(string value)
+        {
+            // substitute all percent sign specifiers
+            value = value.Replace("%%", "%"); // this feels inadequate somehow....
+                                               // TODO: check whether this logic works correctly
+
+            if (Substitutions?.Any() == true)
+            {
+                foreach (var substitution in Substitutions)
+                {
+                    value = value .Replace($"%{substitution.Key}", substitution.Value);
+                }
+            }
+
+            return value;
+        }
     }
 }

--- a/SharpInit/Units/UnitInstantiationContext.cs
+++ b/SharpInit/Units/UnitInstantiationContext.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SharpInit.Units
+{
+    public class UnitInstantiationContext
+    {
+        public Dictionary<string, string> Substitutions { get; set; }
+
+        public UnitInstantiationContext() { Substitutions = new Dictionary<string, string>(); }
+    }
+}

--- a/SharpInit/Units/UnitParser.cs
+++ b/SharpInit/Units/UnitParser.cs
@@ -15,10 +15,7 @@ namespace SharpInit.Units
         public static T FromFiles<T>(params UnitFile[] files)
             where T : UnitDescriptor => (T)FromFiles(typeof(T), files);
 
-        public static UnitDescriptor FromFiles(Type descriptor_type, params UnitFile[] files) =>
-            FromFiles(default(UnitInstantiationContext), descriptor_type, files); // TODO: replace default(T) with a method that returns a base context
-
-        public static UnitDescriptor FromFiles(UnitInstantiationContext ctx, Type descriptor_type, params UnitFile[] files)
+        public static UnitDescriptor FromFiles(Type descriptor_type, params UnitFile[] files)
         {
             var descriptor = (UnitDescriptor)Activator.CreateInstance(descriptor_type);
             descriptor.Files = files;
@@ -121,18 +118,6 @@ namespace SharpInit.Units
                     var attribute = (UnitPropertyAttribute)prop.GetCustomAttributes(typeof(UnitPropertyAttribute), false)[0];
                     var handler_type = attribute.PropertyType;
                     var last_value = values.Last();
-
-                    // substitute all percent sign specifiers
-                    last_value = last_value.Replace("%%", "%"); // this feels inadequate somehow....
-                                                                // TODO: check whether this logic works correctly
-
-                    if (ctx?.Substitutions != null)
-                    {
-                        foreach (var substitution in ctx.Substitutions)
-                        {
-                            last_value = last_value.Replace($"%{substitution.Key}", substitution.Value);
-                        }
-                    }
 
                     properties_touched.Add(attribute);
 

--- a/SharpInit/Units/UnitParser.cs
+++ b/SharpInit/Units/UnitParser.cs
@@ -15,7 +15,10 @@ namespace SharpInit.Units
         public static T FromFiles<T>(params UnitFile[] files)
             where T : UnitDescriptor => (T)FromFiles(typeof(T), files);
 
-        public static UnitDescriptor FromFiles(Type descriptor_type, params UnitFile[] files)
+        public static UnitDescriptor FromFiles(Type descriptor_type, params UnitFile[] files) =>
+            FromFiles(default(UnitInstantiationContext), descriptor_type, files); // TODO: replace default(T) with a method that returns a base context
+
+        public static UnitDescriptor FromFiles(UnitInstantiationContext ctx, Type descriptor_type, params UnitFile[] files)
         {
             var descriptor = (UnitDescriptor)Activator.CreateInstance(descriptor_type);
             descriptor.Files = files;
@@ -112,6 +115,15 @@ namespace SharpInit.Units
                     var attribute = (UnitPropertyAttribute)prop.GetCustomAttributes(typeof(UnitPropertyAttribute), false)[0];
                     var handler_type = attribute.PropertyType;
                     var last_value = values.Last();
+
+                    // substitute all percent sign specifiers
+                    last_value = last_value.Replace("%%", "%"); // this feels inadequate somehow....
+                                                                // TODO: check whether this logic works correctly
+
+                    foreach(var substitution in ctx?.Substitutions)
+                    {
+                        last_value = last_value.Replace($"%{substitution.Key}", substitution.Value);
+                    }
 
                     properties_touched.Add(attribute);
 

--- a/SharpInit/Units/UnitParser.cs
+++ b/SharpInit/Units/UnitParser.cs
@@ -12,160 +12,164 @@ namespace SharpInit.Units
         private static List<string> TrueAliases = new List<string>() { "true", "yes", "1", "on" };
         private static List<string> FalseAliases = new List<string>() { "false", "no", "0", "off" };
 
-        public static T Parse<T>(string file)
-            where T : UnitFile
+        public static T FromFiles<T>(params UnitFile[] files)
+            where T : UnitDescriptor => (T)FromFiles(typeof(T), files);
+
+        public static UnitDescriptor FromFiles(Type descriptor_type, params UnitFile[] files)
         {
-            var unit = Activator.CreateInstance<T>();
+            var descriptor = (UnitDescriptor)Activator.CreateInstance(descriptor_type);
+            descriptor.Files = files;
 
-            unit.UnitName = Path.GetFileName(file);
-            unit.UnitPath = Path.GetFullPath(file);
+            // TODO: reorder the unit files according to priority
 
-            var ext = Path.GetExtension(file);
-            ext = ext.TrimStart('.');
+            //unit.UnitName = Path.GetFileName(file);
+            //unit.UnitPath = Path.GetFullPath(file);
 
-            // normalize capitalization
-            ext = ext.ToLower();
-
-            if(ext.Length > 1)
-                ext = char.ToUpper(ext[0]) + ext.Substring(1);
-
-            var properties = ParseProperties(file);
-            var properties_touched = new List<UnitPropertyAttribute>();
-
-            unit.Properties = properties.ToDictionary(t => t.Key, t => t.Value); // make a copy of the list of properties and store
-                                                                                 // it in the UnitFile before we go ahead and spoil
-                                                                                 // the props by adding our ephemeral values
-
-            // detect .wants, .requires
-            var directory_maps = new Dictionary<string, string>()
+            foreach (var file in files)
             {
-                {".wants", "Unit/Wants" },
-                {".requires", "Unit/Requires" },
-            };
+                var ext = file.Extension;
+                ext = ext.TrimStart('.');
 
-            foreach(var pair in directory_maps)
-            {
-                if(Directory.Exists(file + pair.Key))
+                // normalize capitalization
+                ext = ext.ToLower();
+
+                if (ext.Length > 1)
+                    ext = char.ToUpper(ext[0]) + ext.Substring(1);
+
+                var properties = file.Properties.ToDictionary(p => p.Key, p => p.Value);
+                var properties_touched = new List<UnitPropertyAttribute>();
+
+                // detect .wants, .requires
+                var directory_maps = new Dictionary<string, string>()
                 {
-                    var prop_name = pair.Value;
+                    {".wants", "Unit/Wants" },
+                    {".requires", "Unit/Requires" },
+                };
 
-                    if (!properties.ContainsKey(prop_name))
-                        properties[prop_name] = new List<string>();
+                foreach (var pair in directory_maps)
+                {
+                    if (Directory.Exists(file + pair.Key))
+                    {
+                        var prop_name = pair.Value;
 
-                    // add the units we found in the relevant dir
-                    properties[prop_name].AddRange(Directory.GetFiles(file + pair.Key).Where(filename => UnitRegistry.UnitTypes.Any(type => filename.EndsWith(type.Key))).Select(Path.GetFileName));
+                        if (!properties.ContainsKey(prop_name))
+                            properties[prop_name] = new List<string>();
+
+                        // add the units we found in the relevant dir
+                        properties[prop_name].AddRange(Directory.GetFiles(file + pair.Key).Where(filename => UnitRegistry.UnitTypes.Any(type => filename.EndsWith(type.Key))).Select(Path.GetFileName));
+                    }
                 }
-            }
 
-            foreach (var property in properties)
-            {
-                var path = property.Key;
-                var values = property.Value;
-
-                var name = string.Join("/", path.Split('/').Skip(1));
-
-                if(name.StartsWith("Condition") || name.StartsWith("Assert"))
+                foreach (var property in properties)
                 {
-                    // handle conditions and assertions separately
-                    if(name.StartsWith("Condition"))
+                    var path = property.Key;
+                    var values = property.Value;
+
+                    var name = string.Join("/", path.Split('/').Skip(1));
+
+                    if (name.StartsWith("Condition") || name.StartsWith("Assert"))
                     {
-                        var condition_name = name.Substring("Condition".Length);
+                        // handle conditions and assertions separately
+                        if (name.StartsWith("Condition"))
+                        {
+                            var condition_name = name.Substring("Condition".Length);
 
-                        if (unit.Conditions.ContainsKey(condition_name))
-                            unit.Conditions[condition_name] = unit.Conditions[condition_name].Concat(values).ToList();
-                        else
-                            unit.Conditions[condition_name] = values.ToList();
-                    }
-                    else if(name.StartsWith("Assert"))
-                    {
-                        var assertion_name = name.Substring("Assert".Length);
+                            if (descriptor.Conditions.ContainsKey(condition_name))
+                                descriptor.Conditions[condition_name] = descriptor.Conditions[condition_name].Concat(values).ToList();
+                            else
+                                descriptor.Conditions[condition_name] = values.ToList();
+                        }
+                        else if (name.StartsWith("Assert"))
+                        {
+                            var assertion_name = name.Substring("Assert".Length);
 
-                        if (unit.Assertions.ContainsKey(assertion_name))
-                            unit.Assertions[assertion_name] = unit.Assertions[assertion_name].Concat(values).ToList();
-                        else
-                            unit.Assertions[assertion_name] = values.ToList();
-                    }
+                            if (descriptor.Assertions.ContainsKey(assertion_name))
+                                descriptor.Assertions[assertion_name] = descriptor.Assertions[assertion_name].Concat(values).ToList();
+                            else
+                                descriptor.Assertions[assertion_name] = values.ToList();
+                        }
 
-                    continue;
-                }
-                
-                var prop = ReflectionHelpers.GetClassPropertyInfoByPropertyPath(typeof(T), path);
-
-                if (prop == null)
-                {
-                    // handle .exec unit paths
-                    // The execution specific configuration options are configured in the [Service], [Socket], [Mount], or [Swap] sections, depending on the unit type.
-                    if (path.StartsWith(ext + "/", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        path = "@" + path.Substring(ext.Length);
-                    }
-
-                    prop = ReflectionHelpers.GetClassPropertyInfoByPropertyPath(typeof(T), path);
-
-                    if(prop == null)
                         continue;
+                    }
+
+                    var prop = ReflectionHelpers.GetClassPropertyInfoByPropertyPath(descriptor_type, path);
+
+                    if (prop == null)
+                    {
+                        // handle .exec unit paths
+                        // The execution specific configuration options are configured in the [Service], [Socket], [Mount], or [Swap] sections, depending on the unit type.
+                        if (path.StartsWith(ext + "/", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            path = "@" + path.Substring(ext.Length);
+                        }
+
+                        prop = ReflectionHelpers.GetClassPropertyInfoByPropertyPath(descriptor_type, path);
+
+                        if (prop == null)
+                            continue;
+                    }
+
+                    var attribute = (UnitPropertyAttribute)prop.GetCustomAttributes(typeof(UnitPropertyAttribute), false)[0];
+                    var handler_type = attribute.PropertyType;
+                    var last_value = values.Last();
+
+                    properties_touched.Add(attribute);
+
+                    switch (handler_type)
+                    {
+                        case UnitPropertyType.String:
+                            prop.SetValue(descriptor, last_value);
+                            break;
+                        case UnitPropertyType.Int:
+                            if (!int.TryParse(last_value, out int prop_val_int))
+                                break; // for now
+                            prop.SetValue(descriptor, prop_val_int);
+                            break;
+                        case UnitPropertyType.Bool:
+                            if (TrueAliases.Contains(last_value.ToLower()))
+                                prop.SetValue(descriptor, true);
+                            else if (FalseAliases.Contains(last_value.ToLower()))
+                                prop.SetValue(descriptor, false);
+                            break;
+                        case UnitPropertyType.StringList:
+                            prop.SetValue(descriptor, values);
+                            break;
+                        case UnitPropertyType.StringListSpaceSeparated:
+                            prop.SetValue(descriptor, values.SelectMany(s => SplitSpaceSeparatedValues(s)).ToList());
+                            break;
+                        case UnitPropertyType.Time:
+                            prop.SetValue(descriptor, ParseTimeSpan(last_value));
+                            break;
+                        case UnitPropertyType.Enum:
+                            prop.SetValue(descriptor, Enum.Parse(attribute.EnumType, last_value.Replace("-", ""), true));
+                            break;
+                    }
                 }
 
-                var attribute = (UnitPropertyAttribute)prop.GetCustomAttributes(typeof(UnitPropertyAttribute), false)[0];
-                var handler_type = attribute.PropertyType;
-                var last_value = values.Last();
+                // initialize default values of unspecified properties
+                // also initialize all List<string>s to make our life easier
+                var reflection_properties = descriptor_type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-                properties_touched.Add(attribute);
-
-                switch (handler_type)
+                foreach (var prop in reflection_properties)
                 {
-                    case UnitPropertyType.String:
-                        prop.SetValue(unit, last_value);
-                        break;
-                    case UnitPropertyType.Int:
-                        if (!int.TryParse(last_value, out int prop_val_int))
-                            break; // for now
-                        prop.SetValue(unit, prop_val_int);
-                        break;
-                    case UnitPropertyType.Bool:
-                        if (TrueAliases.Contains(last_value.ToLower()))
-                            prop.SetValue(unit, true);
-                        else if (FalseAliases.Contains(last_value.ToLower()))
-                            prop.SetValue(unit, false);
-                        break;
-                    case UnitPropertyType.StringList:
-                        prop.SetValue(unit, values);
-                        break;
-                    case UnitPropertyType.StringListSpaceSeparated:
-                        prop.SetValue(unit, values.SelectMany(s => SplitSpaceSeparatedValues(s)).ToList());
-                        break;
-                    case UnitPropertyType.Time:
-                        prop.SetValue(unit, ParseTimeSpan(last_value));
-                        break;
-                    case UnitPropertyType.Enum:
-                        prop.SetValue(unit, Enum.Parse(attribute.EnumType, last_value.Replace("-", ""), true));
-                        break;
+                    var unit_property_attributes = prop.GetCustomAttributes(typeof(UnitPropertyAttribute), false);
+
+                    if (unit_property_attributes.Length == 0)
+                        continue;
+
+                    var attribute = (UnitPropertyAttribute)unit_property_attributes.FirstOrDefault();
+
+                    if (!properties_touched.Contains(attribute))
+                    {
+                        if (prop.PropertyType == typeof(List<string>) && attribute.DefaultValue == null)
+                            prop.SetValue(descriptor, new List<string>());
+                        else
+                            prop.SetValue(descriptor, attribute.DefaultValue);
+                    }
                 }
             }
 
-            // initialize default values of unspecified properties
-            // also initialize all List<string>s to make our life easier
-            var reflection_properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            foreach(var prop in reflection_properties)
-            {
-                var unit_property_attributes = prop.GetCustomAttributes(typeof(UnitPropertyAttribute), false);
-                
-                if (unit_property_attributes.Length == 0)
-                    continue;
-
-                var attribute = (UnitPropertyAttribute)unit_property_attributes.FirstOrDefault();
-                
-                if (!properties_touched.Contains(attribute))
-                {
-                    if (prop.PropertyType == typeof(List<string>) && attribute.DefaultValue == null)
-                        prop.SetValue(unit, new List<string>());
-                    else
-                        prop.SetValue(unit, attribute.DefaultValue);
-                }
-            }
-
-            return unit;
+            return descriptor;
         }
 
         public static TimeSpan ParseTimeSpan(string str)
@@ -268,6 +272,14 @@ namespace SharpInit.Units
             }
 
             return base_date - zero;
+        }
+
+        public static OnDiskUnitFile ParseFile(string path)
+        {
+            return File.Exists(path) ? new OnDiskUnitFile(path)
+            {
+                Properties = ParseProperties(path)
+            } : null;
         }
 
         private static Dictionary<string, List<string>> ParseProperties(string path)

--- a/SharpInit/Units/UnitRegistry.cs
+++ b/SharpInit/Units/UnitRegistry.cs
@@ -55,7 +55,9 @@ namespace SharpInit.Units
         public static void AddUnitByPath(string path)
         {
             IndexFile(path);
-            AddUnit(CreateUnit(GetUnitName(path)));
+
+            if (!Units.ContainsKey(GetUnitName(path)))
+                AddUnit(CreateUnit(GetUnitName(path)));
         }
 
         public static string GetUnitName(string path)
@@ -76,7 +78,7 @@ namespace SharpInit.Units
             OrderingDependencies.Dependencies.Clear();
             RequirementDependencies.Dependencies.Clear();
 
-            var env_units_parts = (Environment.GetEnvironmentVariable("SHARPINIT_UNIT_PATH") ?? "").Split(':', StringSplitOptions.RemoveEmptyEntries);
+            var env_units_parts = (Environment.GetEnvironmentVariable("SHARPINIT_UNIT_PATH") ?? "").Split(';', StringSplitOptions.RemoveEmptyEntries);
 
             ScanDirectories.Clear();
             ScanDirectories.AddRange(DefaultScanDirectories);

--- a/SharpInit/Units/UnitRegistry.cs
+++ b/SharpInit/Units/UnitRegistry.cs
@@ -201,6 +201,14 @@ namespace SharpInit.Units
 
             var type = UnitTypes[ext];
             var descriptor = GetUnitDescriptor(pure_unit_name);
+            var context = new UnitInstantiationContext();
+
+            if (!string.IsNullOrEmpty(GetUnitParameter(name)))
+            {
+                context.Substitutions["i"] = GetUnitParameter(name);
+            }
+
+            descriptor.InstantiateDescriptor(context);
             return (Unit)Activator.CreateInstance(type, name, descriptor);
         }
 
@@ -210,15 +218,9 @@ namespace SharpInit.Units
             var ext = Path.GetExtension(pure_unit_name);
 
             var type = UnitTypes[ext];
-            var context = new UnitInstantiationContext();
-
-            if (!string.IsNullOrEmpty(GetUnitParameter(name)))
-            {
-                context.Substitutions["i"] = GetUnitParameter(name);
-            }
 
             var files = UnitFiles[pure_unit_name];
-            return UnitParser.FromFiles(context, UnitDescriptorTypes[type], files.ToArray());
+            return UnitParser.FromFiles(UnitDescriptorTypes[type], files.ToArray());
         }
 
         public static void InitializeTypes()

--- a/SharpInitControl/Program.cs
+++ b/SharpInitControl/Program.cs
@@ -1,6 +1,7 @@
 ﻿using SharpInit.Ipc;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -18,9 +19,11 @@ namespace SharpInitControl
             {"restart", RestartUnits },
             {"reload", ReloadUnits },
             {"list", ListUnits },
+            {"list-files", ListUnitFiles },
             {"daemon-reload", RescanUnits },
             {"status", GetUnitStatus },
-            {"describe-deps", DescribeDependencies }
+            {"describe-deps", DescribeDependencies },
+            {"load", LoadUnit }
         };
 
         static IpcConnection Connection { get; set; }
@@ -203,6 +206,34 @@ namespace SharpInitControl
                 Console.WriteLine("Couldn't retrieve the list of loaded units.");
             else
                 Console.WriteLine($"{list.Count} units loaded: [{string.Join(", ", list)}]");
+        }
+
+        static void ListUnitFiles(string verb, string[] args)
+        {
+            var list = Context.ListUnitFiles();
+
+            if (list == null)
+                Console.WriteLine("Couldn't retrieve the list of loaded unit files.");
+            else
+                Console.WriteLine($"{list.Count} unit files loaded: [{string.Join(", ", list)}]");
+        }
+
+        static void LoadUnit(string verb, string[] args)
+        {
+            var path = Path.GetFullPath(args[0]);
+
+            if (File.Exists(path))
+            {
+                var success = Context.LoadUnitFromFile(path);
+                if (success)
+                {
+                    Console.WriteLine($"Successfully indexed unit at \"{path}\".");
+                }
+                else
+                {
+                    Console.WriteLine($"Failed to index unit at \"{path}\".");
+                }
+            }
         }
     }
 }

--- a/SharpInitControl/Program.cs
+++ b/SharpInitControl/Program.cs
@@ -60,12 +60,31 @@ namespace SharpInitControl
                 var deactivation_plan = Context.GetDeactivationPlan(unit);
 
                 Console.WriteLine($"Activation plan for {unit}:");
-                activation_plan.SelectMany(t => t.Value).ToList().ForEach(Console.WriteLine);
+                foreach (var pair in activation_plan)
+                {
+                    var reasons_text = pair.Value.Count == 1 ? "" : $" ({pair.Value.Count} reasons)";
+                    var prefix = pair.Value.Count == 1 ? "  " : "  + ";
+                    Console.WriteLine($"{prefix}{pair.Key}{reasons_text}:");
+                    foreach (var reason in pair.Value)
+                    {
+                        Console.WriteLine($"      {reason}");
+                    }
+                }
+                //activation_plan.Select(t => ).ToList().ForEach(Console.WriteLine);
 
                 Console.WriteLine();
 
                 Console.WriteLine($"Dectivation plan for {unit}:");
-                deactivation_plan.SelectMany(t => t.Value).ToList().ForEach(Console.WriteLine);
+                foreach (var pair in deactivation_plan)
+                {
+                    var reasons_text = pair.Value.Count == 1 ? "" : $" ({pair.Value.Count} reasons)";
+                    var prefix = pair.Value.Count == 1 ? "  " : "  + ";
+                    Console.WriteLine($"{prefix}{pair.Key}{reasons_text}:");
+                    foreach (var reason in pair.Value)
+                    {
+                        Console.WriteLine($"      {reason}");
+                    }
+                }
             }
         }
 

--- a/SharpInitControl/SharpInitControl.csproj
+++ b/SharpInitControl/SharpInitControl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR aims to implement the following:

- [x] Switch to "primitive `UnitFile`s --- merge ---> comprehensive `UnitDescriptor`" system
- [x] Implement unit specifiers (percent sign substitution) in `UnitParser.FromFiles`
- [x] Implement in-memory units and programmatically create the base ones such as `default.target` by default

When complete, this will fulfill the requirements outlined in #2.